### PR TITLE
fix: スケジュールロジック関連の各種修正.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## Event-Calendar-SQLite
-[reserve-sys-sqlite](https://github.com/Benjuwan/reserve-sys-sqlite)をベースにしたイベントカレンダーシステムUIです<br><br>
+[reserve-sys-sqlite](https://github.com/Benjuwan/reserve-sys-sqlite)をベースにしたイベントカレンダーシステムUIです    
 
-任意の会場（場所・部屋）数を用意するとともに、各会場ごとのイベント予約を視覚的に把握及び管理・編集できるようにしています<br>
-ログイン機能を設けて管理者権限のユーザーだけがイベント内容を編集できるようにするのが一般的ですが、アカウント作成・管理が手間というユーザー（またはアカウント作成という部分にハードルを感じる弊社員のような方々）向けに、**「ログイン機能は無し」 + 「管理者専用ページを用意」することで抵抗なく手軽に扱える**ようにしました。<br>
-具体的には`https://{サイトドメイン}/ctrl-schedules`というようにURL末尾に`ctrl-schedules`を付けることで、イベント情報を編集できる管理者専用ページに飛びます。<br><br>
+任意の会場（場所・部屋）数を用意するとともに、各会場ごとのイベント予約を視覚的に把握及び管理・編集できるようにしています  
+ログイン機能を設けて管理者権限のユーザーだけがイベント内容を編集できるようにするのが一般的ですが、アカウント作成・管理が手間というユーザー（またはアカウント作成という部分にハードルを感じる弊社員のような方々）向けに、**「ログイン機能は無し」 + 「管理者専用ページを用意」することで抵抗なく手軽に扱える**ようにしました。  
+具体的には`https://{サイトドメイン}/ctrl-schedules`というようにURL末尾に`ctrl-schedules`を付けることで、イベント情報を編集できる管理者専用ページに飛びます。    
 
 ---
 
@@ -13,17 +13,17 @@
 - ゲストページ（`/`）
 <img width="605" height="848" alt="Image" src="https://github.com/user-attachments/assets/e7a10f73-ecac-4ea9-a6bc-209b1c94e62b" />
 
-- 管理者専用ページ（`/ctrl-schedules`）でのみ登録イベントの編集が可能<br>
+- 管理者専用ページ（`/ctrl-schedules`）でのみ登録イベントの編集が可能  
 ※ゲストページでは`内容修正`ボタンが表示されません
 <img width="615" height="798" alt="Image" src="https://github.com/user-attachments/assets/9b0d5752-d18a-441f-86c0-5f71ba4c9917" />
 
 ---
 
-`prisma`×`SQLite`でイベント予約をビルトインのデータベースに保存・管理する仕様にしています。<br>
+`prisma`×`SQLite`でイベント予約をビルトインのデータベースに保存・管理する仕様にしています。  
 
 - `src/types/rooms-atom.ts`：会場数と予約可能時間（※現状9～19時まで）の設定ファイル
 - `src/constants/adminPagePathName.ts`：管理者専用ページのURLパス文字列
-    - 現状`'ctrl-schedules'`で設定：<br>
+    - 現状`'ctrl-schedules'`で設定：  
     Next.js のファイルシステムベースのルーティングに則り、URLパスを変更したい場合は`src/app`内に希望するページURL名のフォルダ（ディレクトリ）を設けてください（※`layout.tsx`, `page.tsx`は変更せず、そのままでok）
 
 ### 仕様紹介
@@ -62,7 +62,7 @@
 > - **注意:** `npm audit fix --force` を実行すると、Prisma が **v7 から v6 へ強制的にダウングレード**され、破壊的変更が発生するため実行しないでください。
 >
 > **一時的な回避策:**
-> Prisma 側のアップデートを待つ間、`package.json` に以下の `overrides` を追加することで警告を解消。<br>
+> Prisma 側のアップデートを待つ間、`package.json` に以下の `overrides` を追加することで警告を解消。  
 > **今後、Prisma のマイナーアップデート（v7.2.0 など）がリリースされたタイミングで、一度`overrides`を外して`npm audit`を実行し、公式に修正されたか確認してみること**
 ```diff
   ...
@@ -83,7 +83,7 @@
 
 > [!IMPORTANT]
 > - **2025/12/22： prisma@7.2.0 と next@16.1.0 では互換性がなくビルドエラーが発生する**
-> - **問題の詳細**: Next.js 16のTurbopackがPrisma 7の生成コードに対してシンボリックリンクを作成する際、Windows環境で権限エラー(os error 1314)が発生<br>
+> - **問題の詳細**: Next.js 16のTurbopackがPrisma 7の生成コードに対してシンボリックリンクを作成する際、Windows環境で権限エラー(os error 1314)が発生  
 > 応急処置として`package.json`のビルドコマンドを`webpack`を用いる仕様に修正
 > ```diff
 > "scripts": {
@@ -104,7 +104,7 @@
 > [!NOTE]
 > - `npm audit`で定期的に脆弱性のチェックを行う
 > - `npm update`で定期的に（互換性を維持した）更新を行う
->   - `^`（キャレット：「指定されたバージョンからメジャーバージョンを変更しない範囲で最新のバージョンまでを許容」する機能を示す記号）が付いていても油断せず定期的にチェックする<br>例：`"next": "^14.2.12"`の場合、14.2.12以上 15.0.0未満のバージョンが許容される
+>   - `^`（キャレット：「指定されたバージョンからメジャーバージョンを変更しない範囲で最新のバージョンまでを許容」する機能を示す記号）が付いていても油断せず定期的にチェックする  例：`"next": "^14.2.12"`の場合、14.2.12以上 15.0.0未満のバージョンが許容される
 > - `npm outdated`で表示される`Current`と`Wanted`の内容が等しいのが望ましい
 > - 特定ライブラリを最新にするには`npm install ライブラリ名@latest`コマンドを実行する
 
@@ -135,14 +135,14 @@ npx prisma generate
 ```
 
 ## 備考
-- `prisma studio`<br>
+- `prisma studio`  
 `GUI`でテーブル操作できる機能
 ```bash
 # npx prisma studio で起動
 npx prisma studio
 ```
 
-- `prisma`のアップデートコマンド<br>
+- `prisma`のアップデートコマンド  
 ```bash
 npm i --save-dev prisma@latest
 npm i @prisma/client@latest 
@@ -155,7 +155,7 @@ npm i @prisma/client@latest
 ## データベースの仕様（テーブル）更新
 登録内容を変更したい場合、以下フローを実行する必要がある。
 
-- `prisma/schema.prisma`<br>
+- `prisma/schema.prisma`  
 `model`オブジェクトの内容を編集（登録内容を追加・削除）
 - `prisma/schema.prisma`の`model`オブジェクト編集後、以下のコマンドをターミナルに打つ
 ```bash
@@ -167,18 +167,18 @@ npx prisma generate
 ```
 
 > [!NOTE]
-> - `prisma/dev.db-journal`<br>
-> `dev.db-journal`という設定中のデータベース（今回は`SQLite`）の内部処理用ファイルが自動的に生成・削除されるが無視して構わない。<br>
+> - `prisma/dev.db-journal`  
+> `dev.db-journal`という設定中のデータベース（今回は`SQLite`）の内部処理用ファイルが自動的に生成・削除されるが無視して構わない。  
 > `dev.db-journal`は`SQLite`が自動的に管理する`SQLite`のトランザクションログファイルで、データベース操作の一時的な記録を保持している。
 
 ### その他の更新・修正が必要なファイル
 ※以下の更新・修正は本リポジトリにおいてのみ適用されるもので一般的なものではありません。
-- `src/app/components/schedule/todoItems/ts/todoItemType.ts`<br>
+- `src/app/components/schedule/todoItems/ts/todoItemType.ts`  
 登録内容の型情報を編集
 - `src/app/components/schedule/todoItems/TodoForm.tsx`
     - `todoItems`ステートの初期値である`initTodoItems`オブジェクトを編集（オブジェクトに当該登録内容であるプロパティ・キーを追加・削除）
     - （変更した）当該登録内容に関する入力フォームを（`src/app/components/schedule/todoItems/utils`配下に）用意または調整
-- `src/app/api/reservations/`配下の`Route Handlers`の登録内容を編集<br>
+- `src/app/api/reservations/`配下の`Route Handlers`の登録内容を編集  
 （※[前述の`prisma`データベース更新フロー](#データベースの仕様テーブル更新)が済んでいないと進まないので注意）
-    - `POST`, `PUT`に関する`data`オブジェクト内を編集（例：プロパティ・キーの追加など）<br>
+    - `POST`, `PUT`に関する`data`オブジェクト内を編集（例：プロパティ・キーの追加など）  
     ※`data`オブジェクト編集後に型エラーが表示される場合は一旦`VSCode`を閉じてみる

--- a/src/components/rooms/components/ViewCurrentTimeTableDay.tsx
+++ b/src/components/rooms/components/ViewCurrentTimeTableDay.tsx
@@ -10,7 +10,7 @@ function ViewCurrentTimeTableDay({ props }: { props: timeTableDayProps }) {
 
     const [theThisMonth, setThisMonth] = useState<number | undefined>(undefined);
 
-    const isNextMonth: boolean = useMemo(() => isLastWeek && ctrlMultiTimeTable - 7 < 0, [isLastWeek, ctrlMultiTimeTable]);
+    const isNextMonth: boolean = useMemo(() => isLastWeek && ctrlMultiTimeTable - 7 <= 0, [isLastWeek, ctrlMultiTimeTable]);
 
     const isDec: boolean = useMemo(() => theThisMonth === 12, [theThisMonth]);
 
@@ -26,7 +26,6 @@ function ViewCurrentTimeTableDay({ props }: { props: timeTableDayProps }) {
         return () => {
             clearTimeout(timeId);
         }
-
     }, [setThisMonth]);
 
     if (typeof theThisMonth === 'undefined') {


### PR DESCRIPTION
- スケジュールロジック関連の各種修正
  - `src/components/rooms/components/ViewCurrentTimeTableDay.tsx`
  スケジュール日時描画ロジックの修正
  - `src/components/schedule/calendar/hooks/useRemovePastSchedule.ts`
  当日スケジュールが過去スケジュールと誤認されて削除されるバグ対応および、過去スケジュールの削除処理に関するログ出力
  - `README.md`
  改行コードの記述修正（`<br>` -> `  `半角スペース2つで強制改行）